### PR TITLE
complete and test check owner ID for edit/del restaurant info

### DIFF
--- a/controllers/restaurant.js
+++ b/controllers/restaurant.js
@@ -60,25 +60,35 @@ async function createRestaurant(req, res) {
 }
 
 async function editRestaurant(req, res) {
-  try {
-    const data = await modelRestaurant.editRestaurant(
-      req.params.restId,
-      req.body
-    );
-    res.json(data);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ errorMsg: err.message });
+  const restdata = await modelRestaurant.getRestaurantById(req.params.restId);
+  if (!restdata.owner || restdata.owner !== req.user.id) {
+    return res.status(401).json("Unauthorized");
+  } else {
+    try {
+      const data = await modelRestaurant.editRestaurant(
+        req.params.restId,
+        req.body
+      );
+      res.json(data);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ errorMsg: err.message });
+    }
   }
 }
 
 async function deleteRestaurant(req, res) {
-  try {
-    await modelRestaurant.deleteRestaurant(req.params.restId);
-    res.json("data has been deleted.");
-    // res.redirect('/');
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ errorMsg: err.message });
+  const restdata = await modelRestaurant.getRestaurantById(req.params.restId);
+  if (!restdata.owner || restdata.owner !== req.user.id) {
+    return res.status(401).json("Unauthorized");
+  } else {
+    try {
+      await modelRestaurant.deleteRestaurant(req.params.restId);
+      res.json("data has been deleted.");
+      // res.redirect('/');
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ errorMsg: err.message });
+    }
   }
 }

--- a/controllers/restaurant.js
+++ b/controllers/restaurant.js
@@ -61,7 +61,7 @@ async function createRestaurant(req, res) {
 
 async function editRestaurant(req, res) {
   const restdata = await modelRestaurant.getRestaurantById(req.params.restId);
-  if (!restdata.owner || restdata.owner !== req.user.id) {
+  if (!restdata.owner || restdata.owner != req.user.id) {
     return res.status(401).json("Unauthorized");
   } else {
     try {
@@ -79,7 +79,7 @@ async function editRestaurant(req, res) {
 
 async function deleteRestaurant(req, res) {
   const restdata = await modelRestaurant.getRestaurantById(req.params.restId);
-  if (!restdata.owner || restdata.owner !== req.user.id) {
+  if (!restdata.owner || restdata.owner != req.user.id) {
     return res.status(401).json("Unauthorized");
   } else {
     try {


### PR DESCRIPTION
unable to test FE due to all the existing validation workflows (ie, checking of jwt, only displaying of rest info for users with owner roles) so tested the code by attempting to directly edit rest data from BE (through Postman).

In the screenshot below, I had attempted to (i) update and (ii) delete restaurant info for an existing restaurant entry tagged with owner info. Got the feedback msg that its "unauthorised" (expected behaviour).

**original restaurant entry with owner info:**
<img width="863" alt="image" src="https://github.com/jx0906/proj3-backend/assets/142247158/958a1bbc-91e4-4d4f-8a2f-d8bd307b3075">

**(i) Update info -- > got feedback of unauthorised operation - because I'm not logged on as an owner in Postman:**
<img width="865" alt="image" src="https://github.com/jx0906/proj3-backend/assets/142247158/8a5c2cea-7dab-4219-b6c7-246f09a31c2d">

**(ii) Delete info -- > got feedback of unauthorised operation - because I'm not logged on as an owner in Postman:**
<img width="870" alt="image" src="https://github.com/jx0906/proj3-backend/assets/142247158/4aa028ab-eae3-4bfc-a182-08ad4a23724d">
